### PR TITLE
fix: pod install fail

### DIFF
--- a/react-native-maps-ts.podspec
+++ b/react-native-maps-ts.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-maps"
+  s.name         = "react-native-maps-ts"
   s.version      = package['version']
   s.summary      = "React Native Mapview component for iOS + Android"
 


### PR DESCRIPTION
Podspec name should match package name, so that the google-maps isn't
installed automatically.